### PR TITLE
Add overview page for large model training

### DIFF
--- a/large-model-training-essentials.html
+++ b/large-model-training-essentials.html
@@ -1,0 +1,322 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Large Model Training Essentials</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      font-family: "Inter", "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      line-height: 1.6;
+      background: #f5f7fb;
+      color: #1c1f24;
+    }
+
+    body {
+      margin: 0;
+      padding: 32px 12px 64px;
+      display: flex;
+      justify-content: center;
+      background: linear-gradient(180deg, #eef2ff 0%, #f8fafc 100%);
+    }
+
+    main {
+      width: min(900px, 100%);
+      background: #ffffffcc;
+      backdrop-filter: blur(4px);
+      border-radius: 20px;
+      box-shadow: 0 22px 48px rgba(15, 23, 42, 0.16);
+      padding: clamp(28px, 5vw, 54px);
+      box-sizing: border-box;
+    }
+
+    header {
+      text-align: center;
+      margin-bottom: 32px;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: clamp(2rem, 5vw, 2.8rem);
+      color: #1f2937;
+    }
+
+    header p {
+      margin: 12px auto 0;
+      max-width: 640px;
+      color: #4b5563;
+    }
+
+    section {
+      margin-bottom: 36px;
+    }
+
+    h2 {
+      margin-bottom: 12px;
+      font-size: clamp(1.4rem, 4vw, 1.8rem);
+      color: #111827;
+    }
+
+    .step-list {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      gap: 16px;
+    }
+
+    .step {
+      border-radius: 16px;
+      padding: 18px 22px;
+      background: #f8fafc;
+      border: 1px solid #e2e8f0;
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8);
+    }
+
+    .step strong {
+      display: block;
+      font-size: 1.05rem;
+      margin-bottom: 6px;
+      color: #1f2937;
+    }
+
+    .card-grid {
+      display: grid;
+      gap: 18px;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    }
+
+    .card {
+      background: #ffffff;
+      border: 1px solid #dbeafe;
+      border-radius: 16px;
+      padding: 20px;
+      box-shadow: 0 16px 32px rgba(37, 99, 235, 0.08);
+    }
+
+    .card h3 {
+      margin-top: 0;
+      color: #1d4ed8;
+      font-size: 1.15rem;
+    }
+
+    .highlight {
+      border-left: 4px solid #6366f1;
+      padding: 16px 20px;
+      background: #eef2ff;
+      border-radius: 12px;
+      color: #3730a3;
+    }
+
+    dl {
+      display: grid;
+      gap: 12px;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    }
+
+    dt {
+      font-weight: 600;
+      color: #1f2937;
+    }
+
+    dd {
+      margin: 4px 0 0;
+      color: #4b5563;
+    }
+
+    ul {
+      padding-left: 20px;
+      color: #4b5563;
+    }
+
+    footer {
+      font-size: 0.9rem;
+      color: #6b7280;
+      text-align: center;
+      margin-top: 40px;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        background: #0f172a;
+        color: #e2e8f0;
+      }
+
+      body {
+        background: radial-gradient(circle at top, rgba(59, 130, 246, 0.28), transparent), #0f172a;
+      }
+
+      main {
+        background: rgba(15, 23, 42, 0.7);
+        box-shadow: 0 24px 52px rgba(15, 23, 42, 0.6);
+      }
+
+      h1,
+      h2,
+      dt,
+      .card h3 {
+        color: #e0e7ff;
+      }
+
+      header p,
+      dd,
+      ul,
+      .step,
+      footer {
+        color: #cbd5f5;
+      }
+
+      .step {
+        background: rgba(79, 70, 229, 0.1);
+        border-color: rgba(129, 140, 248, 0.3);
+      }
+
+      .card {
+        background: rgba(30, 41, 59, 0.8);
+        border-color: rgba(129, 140, 248, 0.3);
+        box-shadow: 0 18px 36px rgba(30, 41, 59, 0.7);
+      }
+
+      .highlight {
+        background: rgba(165, 180, 252, 0.08);
+        color: #a5b4fc;
+        border-left-color: #818cf8;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <h1>Large Model Training Essentials</h1>
+      <p>
+        A friendly walkthrough of how modern large language models are built, trained, and refined. Use it as
+        a quick primer before diving into technical papers or production deployments.
+      </p>
+    </header>
+
+    <section aria-labelledby="pipeline-overview">
+      <h2 id="pipeline-overview">Training Pipeline at a Glance</h2>
+      <ol class="step-list">
+        <li class="step">
+          <strong>1. Plan the architecture.</strong>
+          Decide how big the network should be, what layers it needs, and how data flows through it.
+        </li>
+        <li class="step">
+          <strong>2. Prepare massive, diverse datasets.</strong>
+          Gather and clean text, code, images, or audio so the model can learn broad patterns.
+        </li>
+        <li class="step">
+          <strong>3. Pre-train on self-supervised objectives.</strong>
+          Let the model predict masked tokens or next words so it develops general language intuition.
+        </li>
+        <li class="step">
+          <strong>4. Post-train for usefulness and safety.</strong>
+          Align the model with user needs through instruction tuning, human feedback, and evaluation loops.
+        </li>
+      </ol>
+    </section>
+
+    <section aria-labelledby="architecture-basics">
+      <h2 id="architecture-basics">Architecture Basics</h2>
+      <div class="card-grid">
+        <article class="card">
+          <h3>Transformers Everywhere</h3>
+          <p>
+            Most large models use transformer blocks that mix attention layers and feed-forward networks. Attention lets
+            the model focus on the most relevant words or tokens in the context.
+          </p>
+        </article>
+        <article class="card">
+          <h3>Scale and Capacity</h3>
+          <p>
+            Model <em>parameters</em> measure size. Scaling laws show that quality improves predictably as you increase
+            parameters, data, and compute—provided all three grow together.
+          </p>
+        </article>
+        <article class="card">
+          <h3>Tokens and Context</h3>
+          <p>
+            Training happens on tokenized text. Larger context windows allow the model to reference more prior tokens,
+            improving coherence for long documents or conversations.
+          </p>
+        </article>
+      </div>
+    </section>
+
+    <section aria-labelledby="pretraining">
+      <h2 id="pretraining">Pre-Training Fundamentals</h2>
+      <div class="highlight">
+        Pre-training is a self-supervised marathon: the model learns statistical structure by predicting what comes
+        next, without needing labeled answers for every example.
+      </div>
+      <ul>
+        <li><strong>Data quality matters:</strong> Deduplication, filtering, and balancing domains prevent the model from overfitting or memorizing noise.</li>
+        <li><strong>Objective choice:</strong> Causal language modeling, masked language modeling, or multimodal objectives teach different habits.</li>
+        <li><strong>Optimization:</strong> Large-batch distributed training with adaptive optimizers (Adam, Adafactor) keeps learning stable.</li>
+        <li><strong>Monitoring:</strong> Loss curves, validation sets, and compute budgets tell you when to stop or adjust hyperparameters.</li>
+      </ul>
+    </section>
+
+    <section aria-labelledby="posttraining">
+      <h2 id="posttraining">Post-Training &amp; Alignment</h2>
+      <div class="card-grid">
+        <article class="card">
+          <h3>Instruction Tuning</h3>
+          <p>
+            Fine-tune on curated prompt–response pairs so the model follows natural language instructions and stays on topic.
+          </p>
+        </article>
+        <article class="card">
+          <h3>Reinforcement Learning from Human Feedback (RLHF)</h3>
+          <p>
+            Collect human preference data, train a reward model, and optimize the base model to produce responses users prefer.
+          </p>
+        </article>
+        <article class="card">
+          <h3>Evaluation &amp; Safety</h3>
+          <p>
+            Measure helpfulness, harmlessness, and honesty. Automatic tests and red-teaming reveal weaknesses before deployment.
+          </p>
+        </article>
+      </div>
+    </section>
+
+    <section aria-labelledby="key-terms">
+      <h2 id="key-terms">Key Terms to Remember</h2>
+      <dl>
+        <div>
+          <dt>Parameter</dt>
+          <dd>A trainable weight inside the network; billions of parameters mean high capacity.</dd>
+        </div>
+        <div>
+          <dt>Token</dt>
+          <dd>The smallest input unit (a word, subword, or character) the model sees at training time.</dd>
+        </div>
+        <div>
+          <dt>Checkpoint</dt>
+          <dd>A saved snapshot of the model's parameters during training, used for recovery or analysis.</dd>
+        </div>
+        <div>
+          <dt>Alignment</dt>
+          <dd>Techniques that make the model's behavior match human goals, preferences, and safety standards.</dd>
+        </div>
+      </dl>
+    </section>
+
+    <section aria-labelledby="takeaways">
+      <h2 id="takeaways">Quick Takeaways</h2>
+      <ul>
+        <li>Great performance requires balancing architecture size, data quality, and compute resources.</li>
+        <li>Pre-training teaches general knowledge; post-training makes the model helpful, polite, and safe.</li>
+        <li>Continuous evaluation and iteration keep the model aligned with user needs over time.</li>
+      </ul>
+    </section>
+
+    <footer>
+      Want to go deeper? Explore research on scaling laws, data curation, and alignment to extend these essentials.
+    </footer>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a standalone HTML page named `large-model-training-essentials.html`
- outline the large model development pipeline with sections on architecture, pre-training, and post-training
- provide accessible styling and concise explanations for key terms and takeaways

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cf03a1d3688328853d676d82de2823