### PR TITLE
Add tabbed layout to CTR calculator web page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,497 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CTR Confidence Interval Calculator</title>
+  <style>
+    :root {
+      font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+      background-color: #f5f7fb;
+      color: #1e1f21;
+    }
+
+    body {
+      margin: 0;
+      display: flex;
+      justify-content: center;
+      align-items: flex-start;
+      min-height: 100vh;
+      padding: 40px 16px 64px;
+      box-sizing: border-box;
+    }
+
+    main {
+      width: min(720px, 100%);
+      background-color: #ffffff;
+      border-radius: 16px;
+      box-shadow: 0 16px 40px rgba(15, 23, 42, 0.15);
+      padding: 32px clamp(24px, 5vw, 56px);
+      box-sizing: border-box;
+    }
+
+    h1 {
+      margin-top: 0;
+      font-size: clamp(1.8rem, 4vw, 2.4rem);
+      text-align: center;
+      color: #1f2937;
+    }
+
+    p.description {
+      text-align: center;
+      color: #4b5563;
+      margin-bottom: 32px;
+      font-size: 1rem;
+      line-height: 1.6;
+    }
+
+    form {
+      display: grid;
+      gap: 20px;
+    }
+
+    .field {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    label {
+      font-weight: 600;
+      color: #1f2937;
+    }
+
+    input, select {
+      padding: 12px 14px;
+      font-size: 1rem;
+      border-radius: 10px;
+      border: 1px solid #d1d5db;
+      background-color: #f9fafb;
+      transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    input:focus, select:focus {
+      outline: none;
+      border-color: #2563eb;
+      box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.15);
+      background-color: #ffffff;
+    }
+
+    button:not(.tab) {
+      padding: 14px 18px;
+      font-size: 1.05rem;
+      border-radius: 12px;
+      border: none;
+      background: linear-gradient(135deg, #2563eb, #1d4ed8);
+      color: #ffffff;
+      font-weight: 700;
+      cursor: pointer;
+      transition: transform 0.15s ease, box-shadow 0.15s ease;
+    }
+
+    button:not(.tab):hover {
+      transform: translateY(-2px);
+      box-shadow: 0 12px 24px rgba(37, 99, 235, 0.25);
+    }
+
+    .tabs {
+      display: flex;
+      gap: 12px;
+      background-color: #e2e8f0;
+      border-radius: 12px;
+      padding: 6px;
+      margin-bottom: 24px;
+    }
+
+    .tab {
+      flex: 1;
+      padding: 12px 14px;
+      border-radius: 10px;
+      border: none;
+      background: transparent;
+      font-weight: 600;
+      color: #475569;
+      cursor: pointer;
+      transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .tab[aria-selected="true"] {
+      background-color: #ffffff;
+      color: #1f2937;
+      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.15);
+    }
+
+    .tab:focus-visible {
+      outline: 3px solid rgba(37, 99, 235, 0.4);
+      outline-offset: 2px;
+    }
+
+    .tab-panel {
+      display: none;
+      animation: fadeIn 0.25s ease;
+    }
+
+    .tab-panel.active {
+      display: block;
+    }
+
+    .results {
+      margin-top: 36px;
+      background-color: #f1f5f9;
+      border-radius: 14px;
+      padding: 24px;
+      display: grid;
+      gap: 16px;
+    }
+
+    .results h2 {
+      margin: 0;
+      font-size: 1.35rem;
+      color: #1f2937;
+    }
+
+    .metric-grid {
+      display: grid;
+      gap: 12px;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    }
+
+    .metric-card {
+      background-color: #ffffff;
+      border-radius: 12px;
+      padding: 18px;
+      box-shadow: 0 8px 16px rgba(15, 23, 42, 0.08);
+    }
+
+    .metric-card h3 {
+      margin: 0;
+      font-size: 1.05rem;
+      color: #475569;
+      font-weight: 600;
+    }
+
+    .metric-card p {
+      margin: 8px 0 0;
+      font-size: 1.4rem;
+      font-weight: 700;
+      color: #111827;
+    }
+
+    .error {
+      color: #dc2626;
+      background-color: #fee2e2;
+      border-radius: 10px;
+      padding: 12px;
+      margin-top: -8px;
+      font-weight: 600;
+    }
+
+    .placeholder-card {
+      margin-top: 24px;
+      background-color: #f8fafc;
+      border-radius: 14px;
+      padding: 24px;
+      box-shadow: inset 0 0 0 1px #e2e8f0;
+      text-align: center;
+      color: #475569;
+    }
+
+    .placeholder-card h2 {
+      margin-top: 0;
+      color: #1f2937;
+    }
+
+    @keyframes fadeIn {
+      from {
+        opacity: 0;
+        transform: translateY(6px);
+      }
+
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+
+    footer {
+      text-align: center;
+      margin-top: 40px;
+      color: #94a3b8;
+      font-size: 0.9rem;
+    }
+
+    @media (max-width: 480px) {
+      body {
+        padding: 24px 12px 48px;
+      }
+
+      .metric-card p {
+        font-size: 1.2rem;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>CTR Confidence Interval Calculator</h1>
+    <p class="description">
+      Quickly estimate the click-through rate (CTR) and its confidence interval for your campaigns.
+      Enter the total number of engagements (clicks) and impressions, adjust the confidence level if needed,
+      and review the resulting metrics instantly.
+    </p>
+
+    <div class="tabs" role="tablist" aria-label="Performance analytics tools">
+      <button
+        type="button"
+        class="tab"
+        id="tab-ctr"
+        role="tab"
+        aria-selected="true"
+        aria-controls="ctr-tab"
+        data-target="ctr-tab"
+      >
+        CTR Confidence Interval
+      </button>
+      <button
+        type="button"
+        class="tab"
+        id="tab-sample"
+        role="tab"
+        aria-selected="false"
+        aria-controls="sample-tab"
+        data-target="sample-tab"
+      >
+        Sample Size Calculator
+      </button>
+      <button
+        type="button"
+        class="tab"
+        id="tab-diff"
+        role="tab"
+        aria-selected="false"
+        aria-controls="difference-tab"
+        data-target="difference-tab"
+      >
+        Statistical Difference
+      </button>
+    </div>
+
+    <section id="ctr-tab" class="tab-panel active" role="tabpanel" tabindex="0" aria-labelledby="tab-ctr">
+      <form id="ctr-form" novalidate>
+        <div class="field">
+          <label for="engagement">Engagements (clicks)</label>
+          <input id="engagement" name="engagement" type="number" min="0" step="1" placeholder="e.g. 420" required>
+        </div>
+
+        <div class="field">
+          <label for="impressions">Impressions</label>
+          <input id="impressions" name="impressions" type="number" min="1" step="1" placeholder="e.g. 12000" required>
+        </div>
+
+        <div class="field">
+          <label for="confidence">Confidence level</label>
+          <select id="confidence" name="confidence">
+            <option value="90">90%</option>
+            <option value="95" selected>95%</option>
+            <option value="98">98%</option>
+            <option value="99">99%</option>
+          </select>
+        </div>
+
+        <button type="submit">Calculate</button>
+        <div id="error" class="error" hidden></div>
+      </form>
+
+      <section class="results" aria-live="polite" aria-atomic="true">
+        <h2>Results</h2>
+        <div class="metric-grid">
+          <article class="metric-card">
+            <h3>Click-Through Rate</h3>
+            <p id="ctr">–</p>
+          </article>
+          <article class="metric-card">
+            <h3>Standard Error</h3>
+            <p id="standard-error">–</p>
+          </article>
+          <article class="metric-card">
+            <h3>Margin of Error</h3>
+            <p id="margin-of-error">–</p>
+          </article>
+        </div>
+        <article class="metric-card">
+          <h3>Confidence Interval</h3>
+          <p id="confidence-interval">–</p>
+        </article>
+      </section>
+    </section>
+
+    <section
+      id="sample-tab"
+      class="tab-panel"
+      role="tabpanel"
+      tabindex="0"
+      aria-labelledby="tab-sample"
+      hidden
+    >
+      <div class="placeholder-card">
+        <h2>Sample Size Calculator</h2>
+        <p>
+          Coming soon. This tab will help you determine the number of impressions required to reach a target
+          margin of error for your click-through rate estimates.
+        </p>
+      </div>
+    </section>
+
+    <section
+      id="difference-tab"
+      class="tab-panel"
+      role="tabpanel"
+      tabindex="0"
+      aria-labelledby="tab-diff"
+      hidden
+    >
+      <div class="placeholder-card">
+        <h2>Statistical Difference</h2>
+        <p>
+          Coming soon. Use this space to compare two click-through rates and understand whether the observed
+          difference is statistically significant.
+        </p>
+      </div>
+    </section>
+
+    <footer>
+      Calculations use a normal approximation (Wald interval). Ensure impressions are sufficiently large for accurate results.
+    </footer>
+  </main>
+
+  <script>
+    const zScores = {
+      90: 1.6448536269514722,
+      95: 1.959963984540054,
+      98: 2.3263478740408408,
+      99: 2.5758293035489004
+    };
+
+    const tabButtons = document.querySelectorAll('.tab');
+    const tabPanels = document.querySelectorAll('.tab-panel');
+
+    function activateTab(targetId) {
+      tabButtons.forEach((button) => {
+        const isActive = button.dataset.target === targetId;
+        button.setAttribute('aria-selected', String(isActive));
+      });
+
+      tabPanels.forEach((panel) => {
+        const isActive = panel.id === targetId;
+        panel.classList.toggle('active', isActive);
+        panel.hidden = !isActive;
+      });
+    }
+
+    tabButtons.forEach((button) => {
+      button.addEventListener('click', () => {
+        const targetId = button.dataset.target;
+        activateTab(targetId);
+
+        const targetPanel = document.getElementById(targetId);
+        if (targetPanel) {
+          targetPanel.focus();
+        }
+      });
+    });
+
+    activateTab('ctr-tab');
+
+    const ctrForm = document.getElementById('ctr-form');
+    const engagementInput = document.getElementById('engagement');
+    const impressionsInput = document.getElementById('impressions');
+    const confidenceInput = document.getElementById('confidence');
+    const ctrOutput = document.getElementById('ctr');
+    const standardErrorOutput = document.getElementById('standard-error');
+    const marginOutput = document.getElementById('margin-of-error');
+    const intervalOutput = document.getElementById('confidence-interval');
+    const errorBox = document.getElementById('error');
+
+    function formatPercent(value) {
+      return (value * 100).toLocaleString(undefined, {
+        maximumFractionDigits: 2,
+        minimumFractionDigits: 2
+      }) + '%';
+    }
+
+    function formatDecimal(value) {
+      return value.toLocaleString(undefined, {
+        maximumFractionDigits: 4,
+        minimumFractionDigits: 4
+      });
+    }
+
+    function showError(message) {
+      errorBox.textContent = message;
+      errorBox.hidden = false;
+    }
+
+    function clearError() {
+      errorBox.hidden = true;
+      errorBox.textContent = '';
+    }
+
+    function updateResults({ ctr, standardError, margin, lowerBound, upperBound }) {
+      ctrOutput.textContent = formatPercent(ctr);
+      standardErrorOutput.textContent = formatDecimal(standardError);
+      marginOutput.textContent = formatPercent(margin);
+      intervalOutput.textContent = `${formatPercent(lowerBound)} – ${formatPercent(upperBound)}`;
+    }
+
+    function calculateMetrics(engagements, impressions, zScore) {
+      const ctr = engagements / impressions;
+      const variance = ctr * (1 - ctr) / impressions;
+      const standardError = Math.sqrt(variance);
+      const margin = zScore * standardError;
+      const lowerBound = Math.max(ctr - margin, 0);
+      const upperBound = Math.min(ctr + margin, 1);
+
+      return { ctr, standardError, margin, lowerBound, upperBound };
+    }
+
+    ctrForm.addEventListener('submit', (event) => {
+      event.preventDefault();
+
+      const engagements = Number(engagementInput.value);
+      const impressions = Number(impressionsInput.value);
+      const confidenceLevel = Number(confidenceInput.value);
+
+      clearError();
+
+      if (!Number.isFinite(engagements) || engagements < 0) {
+        showError('Please enter a non-negative number of engagements.');
+        return;
+      }
+
+      if (!Number.isFinite(impressions) || impressions <= 0) {
+        showError('Impressions must be a positive number.');
+        return;
+      }
+
+      if (engagements > impressions) {
+        showError('Engagements cannot exceed impressions.');
+        return;
+      }
+
+      const zScore = zScores[confidenceLevel];
+      if (!zScore) {
+        showError('Unsupported confidence level.');
+        return;
+      }
+
+      const metrics = calculateMetrics(engagements, impressions, zScore);
+      updateResults(metrics);
+    });
+
+    // Provide sample default values to demonstrate the calculator.
+    engagementInput.value = '420';
+    impressionsInput.value = '12000';
+    ctrForm.dispatchEvent(new Event('submit'));
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a static CTR confidence interval calculator web page with interactive form inputs
- compute CTR, standard error, margin of error, and the confidence interval using selectable confidence levels
- apply modern styling and sample defaults to make the tool easy to use
- introduce tab navigation with placeholders for sample size and statistical difference calculators

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cce480f0d8832883eaf90268ed35e0