### PR TITLE
Remove navigation links from CTR calculator page

### DIFF
--- a/ctr-confidence-interval-calculator.html
+++ b/ctr-confidence-interval-calculator.html
@@ -30,32 +30,6 @@
       box-sizing: border-box;
     }
 
-    nav.resource-links {
-      display: flex;
-      justify-content: center;
-      flex-wrap: wrap;
-      gap: 12px;
-      margin-bottom: 24px;
-    }
-
-    nav.resource-links a {
-      display: inline-block;
-      padding: 10px 16px;
-      border-radius: 999px;
-      background-color: #e0ecff;
-      color: #1d4ed8;
-      font-weight: 600;
-      text-decoration: none;
-      transition: background-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
-    }
-
-    nav.resource-links a:hover,
-    nav.resource-links a:focus {
-      background-color: #2563eb;
-      color: #ffffff;
-      transform: translateY(-1px);
-    }
-
     h1 {
       margin-top: 0;
       font-size: clamp(1.8rem, 4vw, 2.4rem);
@@ -191,12 +165,6 @@
 </head>
   <body>
     <main>
-      <nav class="resource-links" aria-label="Resource navigation">
-        <a href="index.html">Analytics Resource Hub</a>
-        <a href="youth-competitive-soccer-us.html">Competitive Youth Soccer in the U.S.</a>
-        <a href="intermittent-fasting-overview.html">Intermittent Fasting Overview</a>
-        <a href="large-model-training-essentials.html">Large Model Training Essentials</a>
-      </nav>
       <h1>CTR Confidence Interval Calculator</h1>
       <p class="description">
         Quickly estimate the click-through rate (CTR) and its confidence interval for your campaigns.


### PR DESCRIPTION
## Summary
- remove the resource navigation styling block from the CTR calculator page
- delete the navigation markup so the calculator no longer links to other pages

## Testing
- not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68cf4fd721308328a2927c1ffdbb011f