### PR TITLE
Add student council speech page with revision comparisons

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -744,3 +744,103 @@ body.page-electric header .lead {
   font-size: 1.08rem;
 }
 
+
+body.page-speech {
+  --page-background: #f2f5ff;
+  --body-background: radial-gradient(circle at top left, rgba(129, 140, 248, 0.18), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(59, 130, 246, 0.16), transparent 45%),
+    #f2f5ff;
+  --body-padding: clamp(32px, 6vw, 72px) 18px clamp(48px, 9vw, 96px);
+  --body-padding-mobile: 28px 12px 56px;
+  --main-max-width: 960px;
+  --main-padding: clamp(32px, 5vw, 60px);
+  --main-radius: 28px;
+  --main-radius-mobile: 22px;
+  --main-shadow: 0 28px 56px rgba(15, 23, 42, 0.16);
+  --main-border: 1px solid rgba(148, 163, 184, 0.24);
+  --header-align: center;
+  --header-spacing: clamp(28px, 5vw, 44px);
+  --hero-heading-size: clamp(2.1rem, 4.2vw, 2.9rem);
+  --section-spacing: clamp(32px, 6vw, 52px);
+  --heading-color: #1d2d44;
+  --subheading-color: #1f2937;
+  --accent-color: #1d4ed8;
+  --body-text-color: #1f2937;
+  --muted-text-color: #475569;
+  --list-text-color: #475569;
+}
+
+body.page-speech header .lead {
+  max-width: 640px;
+  margin: 0 auto;
+  line-height: 1.7;
+}
+
+body.page-speech .speech-text {
+  display: grid;
+  gap: 18px;
+  font-size: 1.05rem;
+}
+
+body.page-speech .speech-text p {
+  margin: 0;
+}
+
+body.page-speech .revision-section > p {
+  max-width: 720px;
+  margin: 12px auto 28px;
+  color: var(--muted-text-color);
+}
+
+body.page-speech .revision-grid {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+body.page-speech .revision-card {
+  background-color: #ffffff;
+  border-radius: 22px;
+  border: 1px solid rgba(148, 163, 184, 0.26);
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.12);
+  padding: 24px;
+  display: grid;
+  gap: 16px;
+}
+
+body.page-speech .revision-card h3 {
+  margin: 0;
+  color: var(--accent-color);
+  font-size: 1.12rem;
+}
+
+body.page-speech .revision-pair {
+  background-color: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 14px;
+  padding: 14px 16px;
+  display: grid;
+  gap: 8px;
+}
+
+body.page-speech .revision-pair.revised {
+  background-color: #eef2ff;
+  border-color: #c7d2fe;
+}
+
+body.page-speech .revision-label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #475569;
+}
+
+body.page-speech mark {
+  background-color: #fde68a;
+  color: #92400e;
+  padding: 0 4px;
+  border-radius: 4px;
+  box-shadow: inset 0 -1px 0 rgba(234, 179, 8, 0.4);
+}
+

--- a/index.html
+++ b/index.html
@@ -22,6 +22,10 @@
         <h2>Playful SVG Illustration Gallery</h2>
         <p>Explore inline SVG art featuring a bunny, candy, and elephant crafted with vibrant gradients.</p>
       </a>
+      <a class="resource-card" href="student-council-speech.html">
+        <h2>Student Council Speech Enhancements</h2>
+        <p>Review the original speech and see revisions that add energy, clarity, and audience connection.</p>
+      </a>
       <a class="resource-card" href="youth-competitive-soccer-us.html">
         <h2>Competitive Youth Soccer in the U.S.</h2>
         <p>Review participation trends and factors shaping the competitive youth soccer landscape.</p>

--- a/student-council-speech.html
+++ b/student-council-speech.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Student Council Speech Enhancements</title>
+  <link rel="stylesheet" href="assets/styles.css">
+</head>
+<body class="page-speech">
+  <main>
+    <header>
+      <h1>Student Council Speech: Original & Enhancements</h1>
+      <p class="lead">
+        Review the original student council campaign speech and see how targeted revisions can boost energy,
+        clarity, and audience connection.
+      </p>
+    </header>
+
+    <section aria-labelledby="original-speech">
+      <h2 id="original-speech">Original Speech</h2>
+      <div class="speech-text">
+        <p>Hello! I’m running to be one of your student council representatives.</p>
+
+        <p>I’m doing this for two main reasons. First, I want to make school lunch better. A lot of students have been complaining about the food. Second, I want to bring more fun to recess!</p>
+
+        <p>Let me start with what I plan to do about school lunch.
+        I’ll work on bringing more variety to the menu. Sometimes, the only option is a corn dog, and I think it would be great to have more choices — like different vegetables and protein options.</p>
+
+        <p>I also want to improve the quality of the food. One time, a friend and I got yogurt that was expired. That shouldn’t happen. I believe it’s important for us to have healthy, high-quality meals.</p>
+
+        <p>Now, about recess — I want to make it more fun by making sure there’s enough equipment for everyone. For example, we only have two bouncy balls at school, and a lot of kids want to use them but don’t get a turn.</p>
+
+        <p>Thanks for listening! If you like my ideas, please vote for me!</p>
+      </div>
+    </section>
+
+    <section class="revision-section" aria-labelledby="revision-highlights">
+      <h2 id="revision-highlights">Engaging Revision Highlights</h2>
+      <p>
+        Each revision keeps the original meaning while adding vivid detail, audience awareness, or a call to
+        action. Highlighted phrases show the new wording that adds energy or specificity.
+      </p>
+      <div class="revision-grid" role="list">
+        <article class="revision-card" role="listitem">
+          <h3>Opening Greeting</h3>
+          <div class="revision-pair original">
+            <span class="revision-label">Original</span>
+            <p>Hello! I’m running to be one of your student council representatives.</p>
+          </div>
+          <div class="revision-pair revised">
+            <span class="revision-label">Revised</span>
+            <p>Hello, <mark>Falcons</mark>! I’m <mark>excited</mark> to run as one of your student council representatives and <mark>be a stronger voice for our grade</mark>.</p>
+          </div>
+        </article>
+
+        <article class="revision-card" role="listitem">
+          <h3>Why I’m Running</h3>
+          <div class="revision-pair original">
+            <span class="revision-label">Original</span>
+            <p>I’m doing this for two main reasons. First, I want to make school lunch better. A lot of students have been complaining about the food. Second, I want to bring more fun to recess!</p>
+          </div>
+          <div class="revision-pair revised">
+            <span class="revision-label">Revised</span>
+            <p>I’m running for two big reasons. First, I want to make school lunch better because <mark>so many of you have told me the food feels repetitive</mark>. Second, I want to <mark>turn recess into the highlight of our day with more games and shared fun</mark>!</p>
+          </div>
+        </article>
+
+        <article class="revision-card" role="listitem">
+          <h3>Lunch Variety Plan</h3>
+          <div class="revision-pair original">
+            <span class="revision-label">Original</span>
+            <p>Let me start with what I plan to do about school lunch.
+            I’ll work on bringing more variety to the menu. Sometimes, the only option is a corn dog, and I think it would be great to have more choices — like different vegetables and protein options.</p>
+          </div>
+          <div class="revision-pair revised">
+            <span class="revision-label">Revised</span>
+            <p>Let’s start with lunch. I’ll work with our cafeteria team to bring more variety to the menu. Instead of just another corn dog, imagine picking from <mark>fresh veggie sides</mark>, <mark>new proteins</mark>, and <mark>seasonal specials</mark>.</p>
+          </div>
+        </article>
+
+        <article class="revision-card" role="listitem">
+          <h3>Food Quality Assurance</h3>
+          <div class="revision-pair original">
+            <span class="revision-label">Original</span>
+            <p>I also want to improve the quality of the food. One time, a friend and I got yogurt that was expired. That shouldn’t happen. I believe it’s important for us to have healthy, high-quality meals.</p>
+          </div>
+          <div class="revision-pair revised">
+            <span class="revision-label">Revised</span>
+            <p>Quality matters too. A friend and I once opened expired yogurt—that shouldn’t happen. I’ll push for <mark>regular freshness checks</mark> so every meal is <mark>safe</mark>, <mark>healthy</mark>, and <mark>something we’re proud to eat</mark>.</p>
+          </div>
+        </article>
+
+        <article class="revision-card" role="listitem">
+          <h3>Recess Improvements</h3>
+          <div class="revision-pair original">
+            <span class="revision-label">Original</span>
+            <p>Now, about recess — I want to make it more fun by making sure there’s enough equipment for everyone. For example, we only have two bouncy balls at school, and a lot of kids want to use them but don’t get a turn.</p>
+          </div>
+          <div class="revision-pair revised">
+            <span class="revision-label">Revised</span>
+            <p>For recess, I want to make sure fun never runs out. Right now we only have two bouncy balls, so lots of friends miss out. I’ll organize an <mark>equipment wishlist</mark> and <mark>rotating game stations</mark> so everyone gets a turn.</p>
+          </div>
+        </article>
+
+        <article class="revision-card" role="listitem">
+          <h3>Closing Call to Action</h3>
+          <div class="revision-pair original">
+            <span class="revision-label">Original</span>
+            <p>Thanks for listening! If you like my ideas, please vote for me!</p>
+          </div>
+          <div class="revision-pair revised">
+            <span class="revision-label">Revised</span>
+            <p>Thanks for listening! If these ideas <mark>sound exciting</mark>, I’d be honored to <mark>earn your vote and work hard for you</mark>.</p>
+          </div>
+        </article>
+      </div>
+    </section>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated page that presents the original student council speech alongside highlighted revision ideas
- extend the shared stylesheet with layout and highlighting styles for the new speech comparison page
- link the new resource from the hub index for easy discovery

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d0b65dded88328b768b000934c9051