### PR TITLE
Add geometry walkthrough for square difference

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,10 @@
         <h2>Playful SVG Illustration Gallery</h2>
         <p>Explore inline SVG art featuring a bunny, candy, and elephant crafted with vibrant gradients.</p>
       </a>
+      <a class="resource-card" href="visual-math-55x55-minus-50x50.html">
+        <h2>Square Grid Difference Walkthrough</h2>
+        <p>See how colorful strips and corners make 55 × 55 − 50 × 50 easy for young learners to understand.</p>
+      </a>
       <a class="resource-card" href="student-council-speech.html">
         <h2>Student Council Speech Enhancements</h2>
         <p>Review the original speech and see revisions that add energy, clarity, and audience connection.</p>

--- a/visual-math-55x55-minus-50x50.html
+++ b/visual-math-55x55-minus-50x50.html
@@ -1,0 +1,398 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Seeing 55 × 55 − 50 × 50 with Squares</title>
+  <link rel="stylesheet" href="assets/styles.css">
+  <style>
+    body.page-geometry {
+      --body-background: radial-gradient(circle at top, #eff6ff, #ffffff 55%);
+      --body-padding: clamp(40px, 8vh, 64px) clamp(18px, 6vw, 42px) clamp(64px, 10vh, 96px);
+      --main-max-width: 960px;
+      --main-padding: clamp(28px, 6vw, 56px);
+      --main-radius: 28px;
+      --main-shadow: 0 28px 56px rgba(37, 99, 235, 0.18);
+      --unit-size: clamp(4px, 0.9vw, 6px);
+    }
+
+    .page-geometry header h1 {
+      color: #1d4ed8;
+    }
+
+    .page-geometry header .lead {
+      margin-top: 16px;
+      font-size: 1.1rem;
+      color: #1e293b;
+    }
+
+    .intro-card {
+      margin: 32px 0 12px;
+      background: linear-gradient(135deg, rgba(59, 130, 246, 0.14), rgba(129, 140, 248, 0.18));
+      border-radius: 20px;
+      padding: clamp(20px, 4vw, 32px);
+      border: 1px solid rgba(37, 99, 235, 0.25);
+      box-shadow: 0 18px 42px rgba(59, 130, 246, 0.18);
+      color: #0f172a;
+      display: grid;
+      gap: 12px;
+    }
+
+    .intro-card strong {
+      color: #1d4ed8;
+    }
+
+    .visual-stage {
+      display: grid;
+      gap: clamp(20px, 4vw, 36px);
+      margin-top: clamp(36px, 6vw, 52px);
+      align-items: center;
+    }
+
+    @media (min-width: 760px) {
+      .visual-stage {
+        grid-template-columns: auto 1fr;
+      }
+    }
+
+    .stage-visual {
+      width: calc(var(--unit-size) * 55);
+      height: calc(var(--unit-size) * 55);
+      position: relative;
+      border-radius: 24px;
+      border: 4px solid rgba(37, 99, 235, 0.8);
+      background-color: rgba(191, 219, 254, 0.75);
+      background-image: linear-gradient(90deg, rgba(59, 130, 246, 0.28) 1px, transparent 1px),
+        linear-gradient(0deg, rgba(59, 130, 246, 0.28) 1px, transparent 1px);
+      background-size: var(--unit-size) var(--unit-size);
+      box-shadow: 0 24px 42px rgba(30, 64, 175, 0.18);
+      overflow: hidden;
+      animation: pop-in 0.9s ease both;
+    }
+
+    .stage-visual::after {
+      content: "";
+      position: absolute;
+      inset: 10px;
+      border-radius: 18px;
+      border: 2px dashed rgba(37, 99, 235, 0.15);
+      pointer-events: none;
+    }
+
+    .stage-visual .inner-grid {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: calc(var(--unit-size) * 50);
+      height: calc(var(--unit-size) * 50);
+      background: linear-gradient(135deg, rgba(16, 185, 129, 0.16), rgba(52, 211, 153, 0.28));
+      border: 3px solid rgba(5, 150, 105, 0.75);
+      border-radius: 20px 0 0 0;
+      box-shadow: inset 0 0 0 1px rgba(16, 185, 129, 0.3);
+      background-image: linear-gradient(90deg, rgba(16, 185, 129, 0.32) 1px, transparent 1px),
+        linear-gradient(0deg, rgba(16, 185, 129, 0.32) 1px, transparent 1px);
+      background-size: var(--unit-size) var(--unit-size);
+    }
+
+    .stage-visual .strip-vertical,
+    .stage-visual .strip-horizontal,
+    .stage-visual .corner-square {
+      position: absolute;
+      border-radius: 12px;
+      box-shadow: 0 12px 24px rgba(248, 113, 113, 0.25);
+    }
+
+    .stage-visual .strip-vertical {
+      width: calc(var(--unit-size) * 5);
+      height: calc(var(--unit-size) * 50);
+      top: 0;
+      right: 0;
+      background: linear-gradient(180deg, #fb923c, #f97316);
+      border-radius: 0 20px 0 0;
+    }
+
+    .stage-visual .strip-horizontal {
+      width: calc(var(--unit-size) * 50);
+      height: calc(var(--unit-size) * 5);
+      left: 0;
+      bottom: 0;
+      background: linear-gradient(90deg, #facc15, #f97316);
+      border-radius: 0 0 0 20px;
+    }
+
+    .stage-visual .corner-square {
+      width: calc(var(--unit-size) * 5);
+      height: calc(var(--unit-size) * 5);
+      right: 0;
+      bottom: 0;
+      background: linear-gradient(135deg, #f43f5e, #fb7185);
+      border-radius: 0 0 20px 0;
+      box-shadow: 0 14px 30px rgba(236, 72, 153, 0.28);
+    }
+
+    .stage-text h2 {
+      margin-top: 0;
+      color: #0f172a;
+      font-size: clamp(1.4rem, 4.5vw, 1.9rem);
+    }
+
+    .stage-text p {
+      font-size: 1.05rem;
+      color: #334155;
+      margin: 14px 0;
+    }
+
+    .step-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      background: linear-gradient(135deg, #2563eb, #7c3aed);
+      color: #ffffff;
+      font-weight: 600;
+      padding: 6px 14px;
+      border-radius: 999px;
+      font-size: 0.9rem;
+      letter-spacing: 0.02em;
+      box-shadow: 0 12px 24px rgba(99, 102, 241, 0.26);
+    }
+
+    .stage-text ul {
+      margin: 16px 0 0;
+      padding-left: 22px;
+      color: #475569;
+      font-size: 1rem;
+    }
+
+    .stage-text ul li {
+      margin-top: 10px;
+    }
+
+    .stage-visual.stage-4 {
+      overflow: visible;
+    }
+
+    .stage-visual.stage-4 .strip-vertical,
+    .stage-visual.stage-4 .strip-horizontal,
+    .stage-visual.stage-4 .corner-square {
+      box-shadow: 0 16px 32px rgba(249, 115, 22, 0.28);
+    }
+
+    .stage-visual.stage-4 .strip-label,
+    .stage-visual.stage-4 .corner-label {
+      position: absolute;
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      background: rgba(255, 255, 255, 0.95);
+      color: #0f172a;
+      font-weight: 600;
+      padding: 6px 12px;
+      border-radius: 14px;
+      font-size: 0.95rem;
+      box-shadow: 0 10px 22px rgba(15, 23, 42, 0.16);
+    }
+
+    .stage-visual.stage-4 .strip-vertical .strip-label {
+      left: calc(100% + clamp(12px, 2vw, 18px));
+      top: 50%;
+      transform: translateY(-50%);
+      white-space: nowrap;
+    }
+
+    .stage-visual.stage-4 .strip-horizontal .strip-label {
+      top: calc(100% + clamp(12px, 2vw, 18px));
+      left: 50%;
+      transform: translateX(-50%);
+      white-space: nowrap;
+    }
+
+    .stage-visual.stage-4 .corner-square .corner-label {
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      background: rgba(15, 23, 42, 0.85);
+      color: #ffffff;
+      font-size: 0.9rem;
+      border-radius: 12px;
+      padding: 6px 10px;
+    }
+
+    .math-summary {
+      margin-top: clamp(48px, 7vw, 64px);
+      background: linear-gradient(145deg, rgba(52, 211, 153, 0.16), rgba(96, 165, 250, 0.18));
+      border-radius: 22px;
+      padding: clamp(24px, 5vw, 36px);
+      border: 1px solid rgba(14, 165, 233, 0.28);
+      box-shadow: 0 20px 40px rgba(14, 116, 144, 0.18);
+    }
+
+    .math-summary h2 {
+      margin-top: 0;
+      color: #0f172a;
+    }
+
+    .math-summary ol {
+      margin: 16px 0 24px;
+      padding-left: 24px;
+      color: #0f172a;
+      font-size: 1.05rem;
+    }
+
+    .math-equation {
+      display: inline-flex;
+      align-items: center;
+      gap: clamp(10px, 2.8vw, 18px);
+      background: #ffffff;
+      padding: 12px 20px;
+      border-radius: 999px;
+      font-weight: 700;
+      color: #1f2937;
+      font-size: clamp(1.15rem, 4vw, 1.45rem);
+      box-shadow: inset 0 0 0 2px rgba(30, 64, 175, 0.15), 0 16px 32px rgba(30, 64, 175, 0.18);
+    }
+
+    .math-equation .symbol {
+      color: #1d4ed8;
+    }
+
+    .math-equation .result {
+      color: #0f766e;
+    }
+
+    .closing-note {
+      margin-top: 20px;
+      font-weight: 600;
+      color: #0f172a;
+      font-size: 1.1rem;
+    }
+
+    .try-it {
+      margin-top: clamp(36px, 6vw, 52px);
+      padding: clamp(20px, 4vw, 30px);
+      border-radius: 20px;
+      background: linear-gradient(135deg, rgba(245, 158, 11, 0.16), rgba(253, 186, 116, 0.28));
+      border-left: 6px solid rgba(245, 158, 11, 0.8);
+      box-shadow: 0 16px 34px rgba(245, 158, 11, 0.24);
+      color: #92400e;
+      font-size: 1rem;
+    }
+
+    .try-it strong {
+      color: #7c2d12;
+    }
+
+    @keyframes pop-in {
+      from {
+        opacity: 0;
+        transform: scale(0.92) translateY(18px);
+      }
+      to {
+        opacity: 1;
+        transform: scale(1) translateY(0);
+      }
+    }
+  </style>
+</head>
+<body class="page-geometry">
+  <main>
+    <header>
+      <h1>Seeing 55 × 55 − 50 × 50 with Squares</h1>
+      <p class="lead">Let’s use colorful grids to picture the math. When we compare a big 55-by-55 square to a 50-by-50 square inside it, we can literally see the difference in area.</p>
+    </header>
+
+    <div class="intro-card">
+      <p><strong>Goal:</strong> figure out how many squares are left when we remove a 50 × 50 grid from a 55 × 55 grid.</p>
+      <p>We will peel the picture apart step by step so the answer feels easy to spot — no long multiplication needed!</p>
+    </div>
+
+    <section class="visual-stage">
+      <div class="stage-visual stage-1" aria-hidden="true"></div>
+      <div class="stage-text">
+        <span class="step-badge">Step 1</span>
+        <h2>Meet the 55 × 55 playground</h2>
+        <p>This giant blue grid shows 55 rows and 55 columns. Imagine each tiny square is one tile on a playground. There are <em>a lot</em> of tiles here!</p>
+        <p>Keep this picture in your mind — it is our starting point before we take any tiles away.</p>
+      </div>
+    </section>
+
+    <section class="visual-stage">
+      <div class="stage-visual stage-2" aria-hidden="true">
+        <div class="inner-grid"></div>
+      </div>
+      <div class="stage-text">
+        <span class="step-badge">Step 2</span>
+        <h2>Spot the 50 × 50 square inside</h2>
+        <p>The green square shows 50 rows and 50 columns tucked in the top-left corner. Those 2,500 tiles are the ones we plan to remove.</p>
+        <p>Notice how a border of blue tiles still sticks out along the right side and the bottom. That border is the part we want to count.</p>
+      </div>
+    </section>
+
+    <section class="visual-stage">
+      <div class="stage-visual stage-3" aria-hidden="true">
+        <div class="inner-grid"></div>
+        <div class="strip-vertical"></div>
+        <div class="strip-horizontal"></div>
+        <div class="corner-square"></div>
+      </div>
+      <div class="stage-text">
+        <span class="step-badge">Step 3</span>
+        <h2>Look at the leftover border pieces</h2>
+        <p>The orange strips are the tiles that were not part of the 50 × 50 square. There are two kinds of pieces:</p>
+        <ul>
+          <li>A tall strip along the right side (five columns wide and 50 rows tall).</li>
+          <li>A long strip along the bottom (five rows tall and 50 columns wide).</li>
+        </ul>
+        <p>The pink corner square is counted in both strips, so we will treat it as its own little piece.</p>
+      </div>
+    </section>
+
+    <section class="visual-stage">
+      <div class="stage-visual stage-4" aria-hidden="true">
+        <div class="inner-grid"></div>
+        <div class="strip-vertical">
+          <span class="strip-label">5 × 50 = 250</span>
+        </div>
+        <div class="strip-horizontal">
+          <span class="strip-label">5 × 50 = 250</span>
+        </div>
+        <div class="corner-square">
+          <span class="corner-label">5 × 5 = 25</span>
+        </div>
+      </div>
+      <div class="stage-text">
+        <span class="step-badge">Step 4</span>
+        <h2>Add the friendly-sized pieces</h2>
+        <p>Now we count each orange part:</p>
+        <ul>
+          <li>The right strip has 5 columns × 50 rows = 250 tiles.</li>
+          <li>The bottom strip has 5 rows × 50 columns = 250 tiles.</li>
+          <li>The corner square has 5 rows × 5 columns = 25 tiles.</li>
+        </ul>
+        <p>These three counts cover every leftover tile exactly once.</p>
+      </div>
+    </section>
+
+    <section class="math-summary" aria-labelledby="math-breakdown">
+      <h2 id="math-breakdown">Put the numbers together</h2>
+      <ol>
+        <li>Add the right strip and the bottom strip: 250 + 250 = 500 tiles.</li>
+        <li>Add the corner square: 500 + 25 = 525 tiles.</li>
+      </ol>
+      <div class="math-equation" role="img" aria-label="250 plus 250 plus 25 equals 525">
+        <span>250</span>
+        <span class="symbol">+</span>
+        <span>250</span>
+        <span class="symbol">+</span>
+        <span>25</span>
+        <span class="symbol">=</span>
+        <span class="result">525</span>
+      </div>
+      <p class="closing-note">So, 55 × 55 − 50 × 50 = 525 tiles!</p>
+    </section>
+
+    <div class="try-it">
+      <strong>Try this idea!</strong> Draw another big square and a slightly smaller square in one corner. Can you count the leftover tiles by splitting them into strips and a corner, just like we did here?
+    </div>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a colorful 55×55 vs 50×50 visualization page that breaks down the leftover area into easy-to-count pieces for young students
- link the new lesson from the index resource grid so it is discoverable from the hub

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68d35841670c8328bafb5f275d37fdc8