### PR TITLE
Remove rounded corners from visual math squares

### DIFF
--- a/visual-math-55x55-minus-50x50.html
+++ b/visual-math-55x55-minus-50x50.html
@@ -59,7 +59,6 @@
       width: calc(var(--unit-size) * 55);
       height: calc(var(--unit-size) * 55);
       position: relative;
-      border-radius: 24px;
       border: 4px solid rgba(37, 99, 235, 0.8);
       background-color: rgba(191, 219, 254, 0.75);
       background-image: linear-gradient(90deg, rgba(59, 130, 246, 0.28) 1px, transparent 1px),
@@ -74,7 +73,6 @@
       content: "";
       position: absolute;
       inset: 10px;
-      border-radius: 18px;
       border: 2px dashed rgba(37, 99, 235, 0.15);
       pointer-events: none;
     }
@@ -87,7 +85,6 @@
       height: calc(var(--unit-size) * 50);
       background: linear-gradient(135deg, rgba(16, 185, 129, 0.16), rgba(52, 211, 153, 0.28));
       border: 3px solid rgba(5, 150, 105, 0.75);
-      border-radius: 20px 0 0 0;
       box-shadow: inset 0 0 0 1px rgba(16, 185, 129, 0.3);
       background-image: linear-gradient(90deg, rgba(16, 185, 129, 0.32) 1px, transparent 1px),
         linear-gradient(0deg, rgba(16, 185, 129, 0.32) 1px, transparent 1px);
@@ -98,7 +95,6 @@
     .stage-visual .strip-horizontal,
     .stage-visual .corner-square {
       position: absolute;
-      border-radius: 12px;
       box-shadow: 0 12px 24px rgba(248, 113, 113, 0.25);
     }
 
@@ -108,7 +104,6 @@
       top: 0;
       right: 0;
       background: linear-gradient(180deg, #fb923c, #f97316);
-      border-radius: 0 20px 0 0;
     }
 
     .stage-visual .strip-horizontal {
@@ -117,7 +112,6 @@
       left: 0;
       bottom: 0;
       background: linear-gradient(90deg, #facc15, #f97316);
-      border-radius: 0 0 0 20px;
     }
 
     .stage-visual .corner-square {
@@ -126,7 +120,6 @@
       right: 0;
       bottom: 0;
       background: linear-gradient(135deg, #f43f5e, #fb7185);
-      border-radius: 0 0 20px 0;
       box-shadow: 0 14px 30px rgba(236, 72, 153, 0.28);
     }
 


### PR DESCRIPTION
## Summary
- remove border-radius styling from the 55×55 visual math grid and its sub-shapes so the pieces display as true squares

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d35c6c4f848328a5a4aa2cd71a1932